### PR TITLE
Fix/issues on mobile

### DIFF
--- a/src/components/usual-suspects/tabs/ChildrenAdolescent.astro
+++ b/src/components/usual-suspects/tabs/ChildrenAdolescent.astro
@@ -14,6 +14,7 @@ const data_card_1 = {
     "Bowed long bones",
     "Fractures",
     "Gracile ribs",
+    "Narrow torax",
     "Metaphyseal flaring",
     "Brittle teeth",
   ],

--- a/src/components/usual-suspects/tabs/ChildrenTab.astro
+++ b/src/components/usual-suspects/tabs/ChildrenTab.astro
@@ -53,7 +53,7 @@ const data_card_4 = {
   title: "Differential diagnoses for hypophosphatasia with shared symptoms:",
   image: "/assets/images/usual-suspects/Suspect-10.png",
   subtitle: "Idiopathic hypercalcemia",
-  subtitle_secondary: "AKA IDP",
+  subtitle_secondary: "IDP",
   subtitle_superscript: "9,10",
   info: "",
   list: [

--- a/src/pages/hpp-profile.astro
+++ b/src/pages/hpp-profile.astro
@@ -839,256 +839,262 @@ const internalNavLinks = [
         </section>
       </article>
 
-      <!-- Prevalence of HPP -->
-      <section id="hpp-prevalence" class="section">
-        <!-- HPP Patients charts -->
-        <div class="hpp-patients__red-string">
-          <picture>
-            <img
-              class="hpp-patients__red-pin"
-              src="/assets/images/hpp-profile/pin.png"
-              alt="Pin"
-            />
-          </picture>
-          <p class="wrapper hpp-patients__disclaimer">
-            Reduced alkaline phosphatase levels during childhood may affect peak
-            bone mass later in life<sup>17,18</sup>
-          </p>
-
-          <span class="hpp-patients__red-string1"></span>
-          <span class="hpp-patients__red-string2"></span>
-        </div>
-
-        <div class="hpp-patients__section">
-          <div class="hpp-patients__section--bg-white">
-            <p class="hpp-patients__section__disclaimer--dk">
-              Reduced alkaline phosphatase levels during childhood may affect <span
-                >peak bone mass later in life<sup>18,19</sup></span
-              >
-            </p>
-            <div class="wrapper">
-              <h5 class="hpp-patients__section__title">
-                Percent of patients with hypophosphatasia fractures
-              </h5>
-
-              <div class="hpp-patients__section__chart">
-                <!-- Desktop chart -->
-                <picture>
-                  <img
-                    class="hpp-patients__section__image"
-                    src="/assets/images/hpp-profile/hpp-patients-chart.png"
-                    alt="HPP Profile"
-                  />
-                </picture>
-
-                <!-- Mobile chart -->
-                <div class="hpp-patients__section__chart--mb">
-                  <img
-                    class="hpp-patients__section__image--mb"
-                    src="/assets/images/hpp-profile/chart1-mb.png"
-                    alt="HPP Profile"
-                  />
-                  <p class="hpp-patients__section__text-chart">
-                    Infants and young children (≤5 years)<sup>25a</sup>
-                  </p>
-                  <img
-                    class="hpp-patients__section__image--mb"
-                    src="/assets/images/hpp-profile/chart2-mb.png"
-                    alt="HPP Profile"
-                  />
-                  <p class="hpp-patients__section__text-chart">
-                    Children and adolescents (5-15 years)<sup>26b</sup>
-                  </p>
-                  <img
-                    class="hpp-patients__section__image--mb"
-                    src="/assets/images/hpp-profile/chart3-mb.png"
-                    alt="HPP Profile"
-                  />
-                  <p class="hpp-patients__section__text-chart">
-                    Adults (≥18 years)<sup>7c</sup>
-                  </p>
-                </div>
-              </div>
-
-              <p
-                class="wrapper hpp-patients__section__content hpp-patients__section__content--a hpp-patients__section__content--dk"
-              >
-                Data from a multinational, noninterventional, retrospective
-                chart review study designed to understand the natural history of
-                48 patients ≤5 years of age with severe perinatal- and
-                infantile-onset HPP. Patients included in the study were those
-                diagnosed with HPP based on at least one of the following: serum
-                biomarker levels (below-normal ALP and above-normal PLP or
-                phosphoethanolamine [PEA]), below-normal ALP and radiographic
-                abnormalities, and/or genetic analysis of the ALPL gene.
-                Additionally, onset of HPP must have occurred prior to 6 months
-                of age based on signs that included at least one of the
-                following: respiratory compromise, rachitic chest deformity,
-                and/or vitamin B<sub>6</sub>-responsive seizures.<sup>25</sup>
-              </p>
-
-              <p
-                class="wrapper hpp-patients__section__content hpp-patients__section__content--b hpp-patients__section__content--dk"
-              >
-                Data from a retrospective, multinational, noninterventional
-                natural history study of childhood HPP in patients 5 to 15 years
-                of age (N=32).<sup>26</sup>
-              </p>
-
-              <p
-                class="wrapper hpp-patients__section__content hpp-patients__section__content--c hpp-patients__section__content--dk"
-              >
-                Combined data from HIPS/HOST, an internet questionnaire and
-                telephone survey that queried demographics, HPP-related illness
-                history, disease progression, and health-related quality of
-                life. One hundred twenty-five adults
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <p
-          class="wrapper hpp-patients__section__content hpp-patients__section__content--a hpp-patients__section__content--mb"
-        >
-          Data from a multinational, noninterventional, retrospective chart
-          review study designed to understand the natural history of 48 patients
-          ≤5 years of age with severe perinatal- and infantile-onset HPP.
-          Patients included in the study were those diagnosed with HPP based on
-          at least one of the following: serum biomarker levels (below-normal
-          ALP and above-normal PLP or phosphoethanolamine [PEA]), below-normal
-          ALP and radiographic abnormalities, and/or genetic analysis of the
-          ALPL gene. Additionally, onset of HPP must have occurred prior to 6
-          months of age based on signs that included at least one of the
-          following: respiratory compromise, rachitic chest deformity, and/or
-          vitamin B<sub>6</sub>-responsive seizures.<sup>25</sup>
-        </p>
-
-        <p
-          class="wrapper hpp-patients__section__content hpp-patients__section__content--b hpp-patients__section__content--mb"
-        >
-          Data from a retrospective, multinational, noninterventional natural
-          history study of childhood HPP in patients 5 to 15 years of age
-          (N=32).<sup>26</sup>
-        </p>
-
-        <p
-          class="wrapper hpp-patients__section__content hpp-patients__section__content--c hpp-patients__section__content--mb"
-        >
-          Combined data from HIPS/HOST, an internet questionnaire and telephone
-          survey that queried demographics, HPP-related illness history, disease
-          progression, and health-related quality of life. One hundred
-          twenty-five adults participated.<sup>7</sup>
-        </p>
-
-        <!-- HPP Patients notes -->
-        <div class="hpp-patients__number-bg">
-          <div class="hpp-patients__notes">
-            <div class="hpp-patients__notes--note">
-              <div class="hpp-patients__notes--red-string red-string"></div>
-
-              <picture>
-                <source
-                  media="(min-width: 768px)"
-                  srcset="/assets/images/hpp-profile/pin--desktop.png"
-                />
-                <img
-                  class="hpp-patients__notes--pin"
-                  src="/assets/images/hpp-profile/pin.png"
-                  alt="HPP patient note pin"
-                />
-              </picture>
-
-              <p class="hpp-patients__notes--content">
-                In a meta-analysis of patients* with hypophosphatasia who were
-                followed through adulthood [N=265], there was a <span
-                  class="color--red">high risk</span
-                > of fractures (one or more, or multiple), gross motor/ambulatory
-                difficulties, pain, and surgery with increasing age.<sup>21</sup
-                >
-                <br />
-                <br />
-                <span class="hpp-patients__notes--note--foot">
-                  Data based on patients with first reported occurrence of HPP
-                  manifestations in adulthood (n=43), in utero (n=30),
-                  infancy/early childhood (n=101), childhood (n=78), adolescence
-                  (n=9), and unreported (n=4).
-                </span>
-              </p>
-            </div>
-
-            <div class="hpp-patients__percentage">
-              <div class="hpp-patients__percentage--red-string red-string">
-              </div>
-
-              <picture>
-                <source
-                  media="(min-width: 768px)"
-                  srcset="/assets/images/hpp-profile/pin--desktop.png"
-                />
-                <img
-                  class="hpp-patients__percentage--pin"
-                  src="/assets/images/hpp-profile/pin.png"
-                  alt="Pin"
-                />
-              </picture>
-
-              <p class="hpp-patients__percentage--text text--center">94%</p>
-              <p class="hpp-patients__percentage--content">
-                of patients* with at least 1 year of follow-up experienced at
-                least 1 manifestation or event that contributed to the <span
-                  class="hpp-patients__percentage--content--text-red"
-                >
-                  clinical burden of hypophosphatasia.<sup>21</sup></span
-                >
-              </p>
-              <p class="wrapper hpp-patients__percentage--disclaimer">
-                *16.5% (43 patients/cases) had their first reported occurrence
-                of HPP manifestations at 18 years of age or older.
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <div class="wrapper hpp-patients__content">
-          <h2 class="hpp__profile__title hpp__profile__title--50">
-            WHY Hypophosphatasia SHOULD<br class="hidden md:block" /> REMAIN ON YOUR
-            RADAR
-          </h2>
-
-          <div class="hpp-patients__red-frame-disclaimer">
-            <p
-              class="hpp-patients__red-frame-disclaimer--content color--white text--center"
-            >
-              Severe HPP occurs in 1:300,000 births and milder HPP has been
-              reported by some sources to occur in up to 1:6,370 births. The
-              overall prevalence of all forms of hypophosphatasia is unknown. It
-              is officially classified as a rare disease.Affected individuals
-              may be unrecognized or misdiagnosed. Globally, HPP affects males
-              and females of all ages and appears to be especially prevalent in
-              people of Caucasian descent.<sup>1,22-24</sup>
-            </p>
-          </div>
-
-          <h2 class="hpp__profile__title">
-            Proper diagnosis of hypophosphatasia is crucial
-          </h2>
-          <p class="hpp__profile__content">
-            Misdiagnosing hypophosphatasia can put patients at risk, with some
-            commonly used therapies prescribed for misdiagnoses negatively
-            impacting their condition.18
-          </p>
-        </div>
-
-        <CTA
-          variation="variant-2"
-          buttonLabel="Usual Suspects"
-          content="Learn the risk of misdiagnosis"
-          linkURL="/usual-suspects/"
-          bypassModal
-        />
-      </section>
     </div>
   </section>
+
+   <!-- Prevalence of HPP -->
+   <section id="hpp-prevalence" class="section">
+    <!-- HPP Patients charts -->
+    <div class="wrapper">
+      <div class="hpp-patients__red-string">
+        <picture>
+          <img
+            class="hpp-patients__red-pin"
+            src="/assets/images/hpp-profile/pin.png"
+            alt="Pin"
+          />
+        </picture>
+        <p class="wrapper hpp-patients__disclaimer">
+          Reduced alkaline phosphatase levels during childhood may affect peak
+          bone mass later in life<sup>17,18</sup>
+        </p>
+  
+        <span class="hpp-patients__red-string1"></span>
+        <span class="hpp-patients__red-string2"></span>
+      </div>
+  
+      <div class="hpp-patients__section">
+        <div class="hpp-patients__section--bg-white">
+          <p class="hpp-patients__section__disclaimer--dk">
+            Reduced alkaline phosphatase levels during childhood may affect <span
+              >peak bone mass later in life<sup>18,19</sup></span
+            >
+          </p>
+          <div class="wrapper">
+            <h5 class="hpp-patients__section__title">
+              Percent of patients with hypophosphatasia fractures
+            </h5>
+  
+            <div class="hpp-patients__section__chart">
+              <!-- Desktop chart -->
+              <picture>
+                <img
+                  class="hpp-patients__section__image"
+                  src="/assets/images/hpp-profile/hpp-patients-chart.png"
+                  alt="HPP Profile"
+                />
+              </picture>
+  
+              <!-- Mobile chart -->
+              <div class="hpp-patients__section__chart--mb">
+                <img
+                  class="hpp-patients__section__image--mb"
+                  src="/assets/images/hpp-profile/chart1-mb.png"
+                  alt="HPP Profile"
+                />
+                <p class="hpp-patients__section__text-chart">
+                  Infants and young children (≤5 years)<sup>25a</sup>
+                </p>
+                <img
+                  class="hpp-patients__section__image--mb"
+                  src="/assets/images/hpp-profile/chart2-mb.png"
+                  alt="HPP Profile"
+                />
+                <p class="hpp-patients__section__text-chart">
+                  Children and adolescents (5-15 years)<sup>26b</sup>
+                </p>
+                <img
+                  class="hpp-patients__section__image--mb"
+                  src="/assets/images/hpp-profile/chart3-mb.png"
+                  alt="HPP Profile"
+                />
+                <p class="hpp-patients__section__text-chart">
+                  Adults (≥18 years)<sup>7c</sup>
+                </p>
+              </div>
+            </div>
+  
+            <p
+              class="wrapper hpp-patients__section__content hpp-patients__section__content--a hpp-patients__section__content--dk"
+            >
+              Data from a multinational, noninterventional, retrospective
+              chart review study designed to understand the natural history of
+              48 patients ≤5 years of age with severe perinatal- and
+              infantile-onset HPP. Patients included in the study were those
+              diagnosed with HPP based on at least one of the following: serum
+              biomarker levels (below-normal ALP and above-normal PLP or
+              phosphoethanolamine [PEA]), below-normal ALP and radiographic
+              abnormalities, and/or genetic analysis of the ALPL gene.
+              Additionally, onset of HPP must have occurred prior to 6 months
+              of age based on signs that included at least one of the
+              following: respiratory compromise, rachitic chest deformity,
+              and/or vitamin B<sub>6</sub>-responsive seizures.<sup>25</sup>
+            </p>
+  
+            <p
+              class="wrapper hpp-patients__section__content hpp-patients__section__content--b hpp-patients__section__content--dk"
+            >
+              Data from a retrospective, multinational, noninterventional
+              natural history study of childhood HPP in patients 5 to 15 years
+              of age (N=32).<sup>26</sup>
+            </p>
+  
+            <p
+              class="wrapper hpp-patients__section__content hpp-patients__section__content--c hpp-patients__section__content--dk"
+            >
+              Combined data from HIPS/HOST, an internet questionnaire and
+              telephone survey that queried demographics, HPP-related illness
+              history, disease progression, and health-related quality of
+              life. One hundred twenty-five adults
+            </p>
+          </div>
+        </div>
+      </div>
+  
+      <p
+        class="wrapper hpp-patients__section__content hpp-patients__section__content--a hpp-patients__section__content--mb"
+      >
+        Data from a multinational, noninterventional, retrospective chart
+        review study designed to understand the natural history of 48 patients
+        ≤5 years of age with severe perinatal- and infantile-onset HPP.
+        Patients included in the study were those diagnosed with HPP based on
+        at least one of the following: serum biomarker levels (below-normal
+        ALP and above-normal PLP or phosphoethanolamine [PEA]), below-normal
+        ALP and radiographic abnormalities, and/or genetic analysis of the
+        ALPL gene. Additionally, onset of HPP must have occurred prior to 6
+        months of age based on signs that included at least one of the
+        following: respiratory compromise, rachitic chest deformity, and/or
+        vitamin B<sub>6</sub>-responsive seizures.<sup>25</sup>
+      </p>
+  
+      <p
+        class="wrapper hpp-patients__section__content hpp-patients__section__content--b hpp-patients__section__content--mb"
+      >
+        Data from a retrospective, multinational, noninterventional natural
+        history study of childhood HPP in patients 5 to 15 years of age
+        (N=32).<sup>26</sup>
+      </p>
+  
+      <p
+        class="wrapper hpp-patients__section__content hpp-patients__section__content--c hpp-patients__section__content--mb"
+      >
+        Combined data from HIPS/HOST, an internet questionnaire and telephone
+        survey that queried demographics, HPP-related illness history, disease
+        progression, and health-related quality of life. One hundred
+        twenty-five adults participated.<sup>7</sup>
+      </p>
+  
+    </div> 
+      <!-- HPP Patients notes -->
+      <div class="hpp-patients__number-bg">
+        <div class="hpp-patients__notes">
+          <div class="hpp-patients__notes--note">
+            <div class="hpp-patients__notes--red-string red-string"></div>
+  
+            <picture>
+              <source
+                media="(min-width: 768px)"
+                srcset="/assets/images/hpp-profile/pin--desktop.png"
+              />
+              <img
+                class="hpp-patients__notes--pin"
+                src="/assets/images/hpp-profile/pin.png"
+                alt="HPP patient note pin"
+              />
+            </picture>
+  
+            <p class="hpp-patients__notes--content">
+              In a meta-analysis of patients* with hypophosphatasia who were
+              followed through adulthood [N=265], there was a <span
+                class="color--red">high risk</span
+              > of fractures (one or more, or multiple), gross motor/ambulatory
+              difficulties, pain, and surgery with increasing age.<sup>21</sup
+              >
+              <br />
+              <br />
+              <span class="hpp-patients__notes--note--foot">
+                Data based on patients with first reported occurrence of HPP
+                manifestations in adulthood (n=43), in utero (n=30),
+                infancy/early childhood (n=101), childhood (n=78), adolescence
+                (n=9), and unreported (n=4).
+              </span>
+            </p>
+          </div>
+  
+          <div class="hpp-patients__percentage">
+            <div class="hpp-patients__percentage--red-string red-string">
+            </div>
+  
+            <picture>
+              <source
+                media="(min-width: 768px)"
+                srcset="/assets/images/hpp-profile/pin--desktop.png"
+              />
+              <img
+                class="hpp-patients__percentage--pin"
+                src="/assets/images/hpp-profile/pin.png"
+                alt="Pin"
+              />
+            </picture>
+  
+            <p class="hpp-patients__percentage--text text--center">94%</p>
+            <p class="hpp-patients__percentage--content">
+              of patients* with at least 1 year of follow-up experienced at
+              least 1 manifestation or event that contributed to the <span
+                class="hpp-patients__percentage--content--text-red"
+              >
+                clinical burden of hypophosphatasia.<sup>21</sup></span
+              >
+            </p>
+            <p class="wrapper hpp-patients__percentage--disclaimer">
+              *16.5% (43 patients/cases) had their first reported occurrence
+              of HPP manifestations at 18 years of age or older.
+            </p>
+          </div>
+        </div>
+      </div>
+  
+    <div class="wrapper">
+      <div class="wrapper hpp-patients__content">
+        <h2 class="hpp__profile__title hpp__profile__title--50">
+          WHY Hypophosphatasia SHOULD<br class="hidden md:block" /> REMAIN ON YOUR
+          RADAR
+        </h2>
+  
+        <div class="hpp-patients__red-frame-disclaimer">
+          <p
+            class="hpp-patients__red-frame-disclaimer--content color--white text--center"
+          >
+            Severe HPP occurs in 1:300,000 births and milder HPP has been
+            reported by some sources to occur in up to 1:6,370 births. The
+            overall prevalence of all forms of hypophosphatasia is unknown. It
+            is officially classified as a rare disease.Affected individuals
+            may be unrecognized or misdiagnosed. Globally, HPP affects males
+            and females of all ages and appears to be especially prevalent in
+            people of Caucasian descent.<sup>1,22-24</sup>
+          </p>
+        </div>
+  
+        <h2 class="hpp__profile__title">
+          Proper diagnosis of hypophosphatasia is crucial
+        </h2>
+        <p class="hpp__profile__content">
+          Misdiagnosing hypophosphatasia can put patients at risk, with some
+          commonly used therapies prescribed for misdiagnoses negatively
+          impacting their condition.18
+        </p>
+      </div>
+    </div>
+    
+  </section>
+  
+  <CTA
+      variation="variant-2"
+      buttonLabel="Usual Suspects"
+      content="Learn the risk of misdiagnosis"
+      linkURL="/usual-suspects/"
+      bypassModal
+    />
 
   <References>
     <p>

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -2883,11 +2883,15 @@
             z-index: 2;
             transform: rotate(-28deg) translateX(-50%);
             transform-origin: left;
-            top: 72%;
 
             @media screen and (min-width: 768px) {
                 top: 0.5rem;
                 transform: rotate(5deg) translateX(-50%);
+            }
+
+            @media screen and (max-width: 768px) {
+                left: 25%;
+                transform: rotate(-28deg) translateX(-50%);
             }
         }
     }


### PR DESCRIPTION
### HPP PROFILE PAGE
- Hero’s red string is in a wrong position on hero
- The internal navigation doesn’t work correctly, that section in the screen is multisystemic symptoms and disease, but the item highlighted is other. 

### USUAL SUSPECTS PAGE
- Missing item in usual suspect children tab
- An extra word (‘AKA’) was found in usual suspects infants tab 