### PR TITLE
fix: :bug: Fix missing period, stay connected modal

### DIFF
--- a/src/components/stay-conected.astro
+++ b/src/components/stay-conected.astro
@@ -261,7 +261,7 @@
                 onchange="validateFormControl(event)"
               />
               <label class="form__control-label" for="terms-and-conditions">
-                I'd like to connect with my local Alexion representative
+                I'd like to connect with my local Alexion representative.
               </label>
             </div>
           </div>


### PR DESCRIPTION
Just one comment by pdf:
- Fix missing period in an option, stay conected modal
